### PR TITLE
fix(embed): recognize classification:tool + soften EMB-004 (M-22 alignment with pm-skills v2.16.0)

### DIFF
--- a/scripts/embed-skills.js
+++ b/scripts/embed-skills.js
@@ -38,7 +38,13 @@ const INCLUDE_PERSONAS = (process.env.PM_INCLUDE_PERSONAS || '').toLowerCase() =
 const ROOT_FILES = ['SKILL.md'];
 const REFERENCE_FILES = ['TEMPLATE.md', 'EXAMPLE.md'];
 const SKILL_PHASES = ['discover', 'define', 'develop', 'deliver', 'measure', 'iterate'];
-const SKILL_CLASSIFICATIONS = ['domain', 'foundation', 'utility'];
+// 2026-05-17: 'tool' added to acknowledge v2.15.0 classification:tool
+// taxonomy (15 sprint-skill members shipped under tool-foundation-sprint-*
+// and tool-design-sprint-* prefixes plus tool-note-and-vote).
+// pm-skills-mcp catalog remains frozen at v2.9.2 build (M-22 maintenance
+// mode); known-classification recognition prevents EMB-004 hard-fails on
+// upstream taxonomy that the MCP tooling does not yet embed-route.
+const SKILL_CLASSIFICATIONS = ['domain', 'foundation', 'utility', 'tool'];
 const ALLOWED_ROOT_ENTRIES = new Set(['SKILL.md', 'references']);
 
 /**
@@ -147,18 +153,36 @@ function validateSkillDirectory(sourcePath, skillDir) {
   const hasValidPhase = phase.length > 0 && SKILL_PHASES.includes(phase);
   const hasValidClassification =
     classification.length > 0 && SKILL_CLASSIFICATIONS.includes(classification);
+  const hasUnknownClassification =
+    classification.length > 0 && !SKILL_CLASSIFICATIONS.includes(classification);
 
   if (!hasValidPhase && !hasValidClassification) {
-    errors.push(
-      createInvariant(
-        'EMB-004',
-        'hard-fail',
-        `Skill '${skillDir}' must provide a valid phase or classification.`,
-        `Set phase (${SKILL_PHASES.join(', ')}) or classification (${SKILL_CLASSIFICATIONS.join(
-          ', '
-        )}) in frontmatter.`
-      )
-    );
+    if (hasUnknownClassification) {
+      // M-22 maintenance-mode posture: pm-skills upstream may introduce
+      // new classifications faster than pm-skills-mcp catches up. Soften
+      // unknown-classification to warning so embed still completes and
+      // the MCP catalog stays roughly in sync. Adds the new value to
+      // SKILL_CLASSIFICATIONS when pm-skills-mcp un-freezes from M-22.
+      warnings.push(
+        createInvariant(
+          'EMB-004',
+          'warning',
+          `Skill '${skillDir}' uses unknown classification '${classification}' (known: ${SKILL_CLASSIFICATIONS.join(', ')}); embedding under maintenance-mode posture.`,
+          `Add '${classification}' to SKILL_CLASSIFICATIONS in scripts/embed-skills.js when MCP un-freezes from M-22.`
+        )
+      );
+    } else {
+      errors.push(
+        createInvariant(
+          'EMB-004',
+          'hard-fail',
+          `Skill '${skillDir}' must provide a valid phase or classification.`,
+          `Set phase (${SKILL_PHASES.join(', ')}) or classification (${SKILL_CLASSIFICATIONS.join(
+            ', '
+          )}) in frontmatter.`
+        )
+      );
+    }
   }
 
   if (fs.existsSync(referencesPath)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -107,7 +107,8 @@ export function loadConfig(): ServerConfig {
 export const SERVER_INFO = {
   name: 'pm-skills-mcp',
   version: '2.9.3',
-  description: 'MCP server exposing 40 product management skills as tools (maintenance mode as of 2026-05-04)',
+  description:
+    'MCP server exposing 40 product management skills as tools (maintenance mode as of 2026-05-04)',
 } as const;
 
 /**

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -302,8 +302,7 @@ const experimentCycle: Workflow = {
 const customerDiscovery: Workflow = {
   id: 'customer-discovery',
   name: 'Customer Discovery',
-  description:
-    'Transform raw research into a clear, validated problem worth solving.',
+  description: 'Transform raw research into a clear, validated problem worth solving.',
   effort: 'standard',
   useCases: [
     'Starting a new product initiative',
@@ -348,8 +347,7 @@ const customerDiscovery: Workflow = {
 const sprintPlanning: Workflow = {
   id: 'sprint-planning',
   name: 'Sprint Planning',
-  description:
-    'Prepare sprint-ready stories with edge case coverage from a backlog or PRD.',
+  description: 'Prepare sprint-ready stories with edge case coverage from a backlog or PRD.',
   effort: 'quick',
   useCases: [
     'Preparing stories for sprint planning',
@@ -440,8 +438,7 @@ const productStrategy: Workflow = {
 const postLaunchLearning: Workflow = {
   id: 'post-launch-learning',
   name: 'Post-Launch Learning',
-  description:
-    'Set up measurement, evaluate results, and capture learnings after a feature ships.',
+  description: 'Set up measurement, evaluate results, and capture learnings after a feature ships.',
   effort: 'comprehensive',
   useCases: [
     'Post-launch feature evaluation',
@@ -493,8 +490,7 @@ const postLaunchLearning: Workflow = {
 const stakeholderAlignment: Workflow = {
   id: 'stakeholder-alignment',
   name: 'Stakeholder Alignment',
-  description:
-    'Build a compelling case for leadership buy-in before committing resources.',
+  description: 'Build a compelling case for leadership buy-in before committing resources.',
   effort: 'standard',
   useCases: [
     'Pitching a new initiative to leadership',
@@ -539,8 +535,7 @@ const stakeholderAlignment: Workflow = {
 const technicalDiscovery: Workflow = {
   id: 'technical-discovery',
   name: 'Technical Discovery',
-  description:
-    'Evaluate technical feasibility and document architecture decisions.',
+  description: 'Evaluate technical feasibility and document architecture decisions.',
   effort: 'standard',
   useCases: [
     'Evaluating a new technology or approach',


### PR DESCRIPTION
## Summary

Two changes to `scripts/embed-skills.js`, both aligning embed-validation with the M-22 maintenance-mode posture:

1. **`SKILL_CLASSIFICATIONS` now includes `'tool'`.** pm-skills v2.15.0 (2026-05-16) shipped 15 skills under `classification: tool` (foundation-sprint family + design-sprint family + tool-note-and-vote standalone). Every embed run since v2.15.0 ship has been failing EMB-004 hard on all 15, blocking the upstream `validate-mcp-sync.yml` workflow.

2. **EMB-004 is now a warning, not a hard-fail, for unrecognized classifications.** Skills with a non-empty but unknown classification get a warning instead of breaking embed. Skills with NEITHER a valid phase NOR any classification value still hard-fail (a genuine defect, distinct from upstream taxonomy lag).

## Why now

pm-skills' doc-stack-modernization session (2026-05-17) surfaced the persistent CI false-positive while running validate-mcp-sync.yml. The companion fix is Layer 1 (pm-skills [#147](https://github.com/product-on-purpose/pm-skills/pull/147)): `continue-on-error: true` on both steps. Layer 1 alone makes CI advisory; Layer 2 (this PR) makes the embed step actually produce useful output instead of an early termination.

## Why not bump pm-skills-mcp version

M-22 maintenance-mode posture: package version stays at 2.9.3 until a security or critical fix warrants a patch release. This embed-script fix is a build-time hygiene improvement, not a published-package behavior change.

## Test plan

- [ ] CI green on this PR (vitest unit tests do not exercise EMB-004 paths; coverage is preserved)
- [ ] After merge: pm-skills PR #147 spike-branch CI shows validate-mcp-sync workflow with warning instead of hard-fail in embed step
- [ ] Future v2.17+ pm-skills classification addition triggers warning, not hard-fail

## Refs

- pm-skills `project_mcp-maintenance-mode.md` (M-22; 2026-05-04)
- pm-skills v2.15.0 ship 2026-05-16 (classification:tool introduction)
- pm-skills v2.16.0 doc-stack-modernization session 2026-05-17
- pm-skills PR #147 (Layer 1 companion)