### PR TITLE
chore(license): set the Apache-2.0 copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -174,7 +174,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Jonathan
+   Copyright 2026 Jonathan Prisant
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Names the copyright holder in the Apache-2.0 LICENSE.

The line was incomplete: either a truncated name (`Copyright 2026 Jonathan`) or the unedited Apache boilerplate placeholder (`Copyright [yyyy] [name of copyright owner]`). Both now read `Copyright 2026 Jonathan Prisant`.

One line, LICENSE only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXcYNxLNAX1BtgUQTmSJuH